### PR TITLE
Finally remove this git conflict markers from Deconvolution by FIR.rst

### DIFF
--- a/docs/Deconvolution by FIR.rst
+++ b/docs/Deconvolution by FIR.rst
@@ -155,11 +155,7 @@ such that the filtered signal
 
 .. math:: \hat{x}[n] = (g\ast y)[n] \qquad n=1,\ldots,M
 
-<<<<<<< HEAD
-is an estimate of the system's input signal at the discrete time points
-=======
 is an estimate of the system's input signal at the discrete time points.
->>>>>>> devel1
 
 Publication
 


### PR DESCRIPTION
Check out the new docs without the strange left-overs: https://pydynamic.readthedocs.io/en/bjoernludwigptb-remove-git-conflict-markers-from-deconvolution-by-fir/Deconvolution%20by%20FIR.html?highlight=HEAD#design-of-the-deconvolution-filter

and with them: https://pydynamic.readthedocs.io/en/latest/Deconvolution%20by%20FIR.html?highlight=HEAD#design-of-the-deconvolution-filter